### PR TITLE
Update `server.js` to redirect to `index.html`

### DIFF
--- a/public/index.html
+++ b/public/index.html
@@ -4,7 +4,7 @@
   </head>
   <body>
 
-    <script src="https://cdn.jsdelivr.net/gh/langflow-ai/langflow-embedded-chat@1.0_alpha/dist/build/static/js/bundle.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/gh/logspace-ai/langflow-embedded-chat@v1.0.3/dist/build/static/js/bundle.min.js"></script>
     <langflow-chat
       window_title="LangFlow Chat UI Test"
       flow_id="YOUR FLOW ID HERE"

--- a/server.js
+++ b/server.js
@@ -3,7 +3,7 @@ const app = express()
 const port = 3000
 
 app.get('/', (req, res) => {
-  res.send('Hello World!')
+  res.redirect('/index.html')
 })
 
 app.use(express.static('public'))


### PR DESCRIPTION
Small update to improve usability. Now browsing to `host_ip_address:3000/` redirects to `index.html` and automatically loads the chatbot. 

Also bumped the version of `langflow-embedded-chat` to stable release version `1.0.3`.